### PR TITLE
fix issue #16

### DIFF
--- a/elastipy/query/bool.py
+++ b/elastipy/query/bool.py
@@ -88,11 +88,22 @@ class Bool(_Bool):
             return q
 
     def __or__(self, other):
+        self_has_and = bool(self.must or self.must_not or self.filter)
+
         if not isinstance(other, Bool):
-            q = copy(self)
-            if q.should:
-                if not q.must and not q.must_not and not q.filter:
+            if not self_has_and:
+                q = copy(self)
+                if other not in q.should:
                     q.should += [other]
-                    return q
+                return q
+
+        else:
+            other_has_and = bool(other.must or other.must_not or other.filter)
+            if not self_has_and and not other_has_and:
+                q = copy(self)
+                for sub_q in other.should:
+                    if sub_q not in q.should:
+                        q.should += [sub_q]
+                return q
 
         return super().__or__(other)

--- a/elastipy/query/bool.py
+++ b/elastipy/query/bool.py
@@ -77,13 +77,12 @@ class Bool(_Bool):
                 q.must += [other]
             return q
         else:
-            if self.should or other.should:
+            if other.should:
                 return super().__and__(other)
 
             q = copy(self)
             for key in ("must", "must_not", "filter"):
                 for o in getattr(other, key):
-                    print(o in getattr(q, key), o, getattr(q, key))
                     if o not in getattr(q, key):
                         setattr(q, key, getattr(q, key) + [o])
             return q

--- a/elastipy/query/bool.py
+++ b/elastipy/query/bool.py
@@ -73,14 +73,18 @@ class Bool(_Bool):
     def __and__(self, other) -> 'Bool':
         if not isinstance(other, Bool):
             q = copy(self)
-            q.must += [other]
+            if other not in q.must:
+                q.must += [other]
             return q
-
         else:
+            if self.should or other.should:
+                return super().__and__(other)
+
             q = copy(self)
-            for key in ("must", "must_not", "should", "filter"):
+            for key in ("must", "must_not", "filter"):
                 for o in getattr(other, key):
-                    if o not in getattr(self, key):
+                    print(o in getattr(q, key), o, getattr(q, key))
+                    if o not in getattr(q, key):
                         setattr(q, key, getattr(q, key) + [o])
             return q
 

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -134,6 +134,19 @@ class TestBool(unittest.TestCase):
             self.q2() | query.Bool(must=self.q1())
         )
 
+    def test_or_no_duplicates(self):
+        self.assertEqualQuery(
+            query.Bool(should=[self.q1(), self.q2()]),
+            query.Bool(should=[self.q1()]) | query.Bool(should=[self.q1()])
+            | query.Bool(should=[self.q2()]) | query.Bool(should=[self.q2()])
+        )
+
+    def test_or_no_duplicates_with_other(self):
+        self.assertEqualQuery(
+            query.Bool(should=[self.q1(), self.q2()]),
+            query.Bool(should=[self.q1()]) | self.q1() | self.q2() | self.q2()
+        )
+
     def test_or_regression_16(self):
         """
         https://github.com/netzkolchose/elastipy/issues/16

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -197,6 +197,15 @@ class TestBool(unittest.TestCase):
             s.to_dict(),
         )
 
+    def test_or_regression_16_with_other(self):
+        self.assertEqualQuery(
+            query.Bool(
+                should=[self.q1(), self.q2()],
+                must=[self.q3()],
+            ),
+            (self.q1() | self.q2()) & self.q3()
+        )
+
     def test_and_with_other(self):
         self.assertEqualQuery(
             query.Bool(must=[self.q1(), self.q2()]),

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -8,6 +8,8 @@ from elastipy import Search, query
 
 class TestBool(unittest.TestCase):
 
+    maxDiff = 10_000
+
     def q1(self):
         return query.Term("a", "1")
 
@@ -19,15 +21,21 @@ class TestBool(unittest.TestCase):
 
     def q4(self):
         return query.Term("d", "4")
-
+    
+    def assertEqualQuery(self, expected, real):
+        if expected != real:
+            raise AssertionError(
+                f"Expected:\n{expected}\nGot:\n{real}"
+            )
+    
     def test_single_arg(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(must=[self.q1()]),
             query.Bool(must=self.q1())
         )
 
     def test_transform_dict(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(must=[query.Term("a", 1)]),
             query.Bool(must=[{"term": {"a": {"value": 1}}}])
         )
@@ -41,17 +49,17 @@ class TestBool(unittest.TestCase):
 
     def test_copy_bug(self):
         s = Search().copy().bool(must=self.q1())
-        self.assertEqual(
+        self.assertEqualQuery(
             [self.q1()],
             s.get_query().parameters["must"]
         )
 
         s = s.bool(must_not=self.q2())
-        self.assertEqual(
+        self.assertEqualQuery(
             [self.q1()],
             s.get_query().parameters["must"]
         )
-        self.assertEqual(
+        self.assertEqualQuery(
             [self.q2()],
             s.get_query().parameters["must_not"]
         )
@@ -59,27 +67,27 @@ class TestBool(unittest.TestCase):
     def test_assignment(self):
         q = query.Bool(must=[self.q1()])
         q.filter = [self.q2()]
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(must=[self.q1()], filter=[self.q2()]),
             q
         )
-        self.assertEqual(2, len(q.parameters))
+        self.assertEqualQuery(2, len(q.parameters))
 
         q.must = [self.q3()]
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(must=[self.q3()], filter=[self.q2()]),
             q
         )
 
         q.must = None  # default value
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(filter=[self.q2()]),
             q
         )
-        self.assertEqual(1, len(q.parameters))
+        self.assertEqualQuery(1, len(q.parameters))
 
     def test_or_1(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(
                 should=[self.q1(), self.q2()],
             ),
@@ -87,7 +95,7 @@ class TestBool(unittest.TestCase):
         )
 
     def test_or_2(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(
                 should=[query.Bool(must=self.q1()), query.Bool(must=self.q2())],
             ),
@@ -95,7 +103,7 @@ class TestBool(unittest.TestCase):
         )
 
     def test_or_3(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(
                 should=[self.q1(), self.q2()],
             ),
@@ -103,7 +111,7 @@ class TestBool(unittest.TestCase):
         )
 
     def test_or_4(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(
                 should=[query.Bool(must=self.q1()), self.q2()],
             ),
@@ -111,7 +119,7 @@ class TestBool(unittest.TestCase):
         )
 
     def test_or_5(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(
                 should=[query.Bool(must=self.q1(), should=self.q3()), self.q2()],
             ),
@@ -119,11 +127,110 @@ class TestBool(unittest.TestCase):
         )
 
     def test_or_6(self):
-        self.assertEqual(
+        self.assertEqualQuery(
             query.Bool(
                 should=[self.q2(), query.Bool(must=self.q1())],
             ),
             self.q2() | query.Bool(must=self.q1())
+        )
+
+    def test_or_regression_16(self):
+        """
+        https://github.com/netzkolchose/elastipy/issues/16
+        """
+        s = (
+            (self.q1() | self.q2())
+            & (
+                (self.q2() & self.q3())
+                | (self.q2() & self.q4())
+            )
+        )
+        self.assertEqualQuery(
+            query.Bool(
+                must=[
+                    query.Bool(should=[self.q1(), self.q2()]),
+                    query.Bool(should=[
+                        query.Bool(must=[self.q2(), self.q3()]),
+                        query.Bool(must=[self.q2(), self.q4()]),
+                    ]),
+                ],
+            ),
+            s
+        )
+        self.assertEqual(
+            {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {"term": {"a": {"value": "1"}}},
+                                    {"term": {"b": {"value": "2"}}},
+                                ]
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {"term": {"b": {"value": "2"}}},
+                                                {"term": {"c": {"value": "3"}}},
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {"term": {"b": {"value": "2"}}},
+                                                {"term": {"d": {"value": "4"}}},
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            s.to_dict(),
+        )
+
+    def test_and_with_other(self):
+        self.assertEqualQuery(
+            query.Bool(must=[self.q1(), self.q2()]),
+            query.Bool(must=[self.q1()]) & self.q2()
+        )
+
+    def test_and_avoid_multiples_with_other(self):
+        self.assertEqualQuery(
+            query.Bool(must=[self.q1(), self.q2()]),
+            query.Bool(must=[self.q1()]) & self.q2() & self.q2()
+        )
+
+    def test_and_avoid_multiples(self):
+        self.assertEqualQuery(
+            query.Bool(must=[self.q1(), self.q2()]),
+            query.Bool(must=[self.q1()]) & query.Bool(must=[self.q2()]) & query.Bool(must=[self.q2()])
+        )
+
+    def test_and_all(self):
+        self.assertEqualQuery(
+            query.Bool(
+                must=[self.q1(), self.q2()],
+                must_not=[self.q2(), self.q3()],
+                filter=[self.q3(), self.q4()],
+            ),
+            query.Bool(
+                must=[self.q1()],
+                must_not=[self.q2()],
+                filter=[self.q3()],
+            ) & query.Bool(
+                must=[self.q2()],
+                must_not=[self.q3()],
+                filter=[self.q4()],
+            ),
         )
 
 


### PR DESCRIPTION
previously, `bool.should` entries were concatenated in `__and__` calls.
Now query A and B are wrapped in a container `bool.must=[A, B]` if
a `should` entry exists in A or B.
If not, the `must`, `must_not` and `filter` entries are still concatenated,
which, i think, is perfectly valid because they all represent AND combinations.